### PR TITLE
Added main branch to push & pull events

### DIFF
--- a/sample-workflow-pull-request.yml
+++ b/sample-workflow-pull-request.yml
@@ -7,6 +7,7 @@ on: # Controls when the action will run. Triggers the workflow on pull request e
     types: [opened, reopened, synchronize] #Types specify which pull request events will trigger the workflow. For more events refer Github Actions documentation.
     branches:
       - master
+      - main
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel - this job is specifically configured to use the Checkmarx CxFlow Action
 jobs:

--- a/sample-workflow.yml
+++ b/sample-workflow.yml
@@ -6,9 +6,9 @@ name: CxFlow
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel - this job is specifically configured to use the Checkmarx CxFlow Action
 jobs:


### PR DESCRIPTION
GitHub has changed the default branch from master to main.  These two files previously just referenced just master and not both master and main.