### PR TITLE
Remove calls to the Alpine package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 #Use CxFlow Base image
 FROM checkmarx/cx-flow
-#Apply any updates
-RUN apk update && apk upgrade
 #Copy the entrypoint script and properties used for the action
 COPY entrypoint.sh /app/entrypoint.sh
 #Make it executable


### PR DESCRIPTION
The Docker image currently updates the Alpine Linux package manager's
index of available packages ("apk update") and upgrades any installed
packages ("apk upgrade"). This fails in the case that the GitHub
action is being run from a private runner without access to the Alpine
Linux package registry.