### PR TITLE
Rewrite section on file filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,35 @@ _Note: It is recommentded to leverage secrets for any sensitive inputs_
 
 ## Filters
 
-_Note: For filtering files in the params input, it is necessary to escape special characters_
+Files can be excluded from the zipfile that CxFlow uploads to CxSAST by adding the `--cx-flow.zip-exclude` command line option to the `params` property in the GitHub Action configuration. The value of this option is a comma-separated list of regular expressions. Any file whose full path is matched by one of these regular expressions will be excluded from the zipfile.
+
+The regular expression syntax is that used by the [`java.util.regex.Pattern`](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) class.
 
 Here is an example of filtering files:
 
---cx-flow.zip-exclude="\\.git\\/.\*,\\.github\\/.\*,apps\\/tests\\/.\*,apps\\/docs\/.\*,apps\\/web\\/.\*"
+```
+--cx-flow.zip-exclude=\.git/.*,\.github/.*,apps/tests/.*,apps/docs/.*,apps/web/.*
+```
 
-* Excluding the .git and .github folders from the zip file is highly important! Otherwise each commit will trigger a full scan due to changes in the files under these folders
-* To recursively exclude all files under any folder named "tests" for example, add the following to the -cx-flow.zip-exclude line:  
---cx-flow.zip-exclude="\\.git\\/.\*,\\.github\\/.\*,tests\\/.\*,.\+\\/tests\\/.\*"
+This will exclude all files and subdirectories found under the `.git`, `.github`, `apps/tests`, `apps/docs`, and `apps/web` directories.
+
+* Excluding the `.git` and `.github` folders from the zip file is highly important! Otherwise each commit will trigger a full scan due to changes in the files under these directories (which do not contain files that CxSAST will scan anyway).
+* Do not enclose the list of regular expressions in quotes as these will be taken to be part of the regular expression(s).
+
+The CxFlow log will show you the regular expressions used:
+
+```
+2023-01-25 03:14:45.232  INFO 8 --- [           main] c.c.f.u.ZipUtils                          [vLhiqdlb] : Applying exclusions: \.git/.*,\\.github/.*
+```
+
+If DEBUG logging is enabled, each matching file will be logged:
+
+```
+2023-01-25 03:14:45.240 DEBUG 8 --- [           main] c.c.f.u.ZipUtils                          [vLhiqdlb] : match: \.git/.*$1.git/HEAD
+2023-01-25 03:14:45.240 DEBUG 8 --- [           main] c.c.f.u.ZipUtils                          [vLhiqdlb] : match: \.git/.*$1.git/index
+2023-01-25 03:14:45.241 DEBUG 8 --- [           main] c.c.f.u.ZipUtils                          [vLhiqdlb] : match: \.git/.*$1.git/config
+...
+```
 
 ## Outputs
 


### PR DESCRIPTION
Experimentation shows that escaping is not necessary except when escaping a character that has special meaning for the regular expression engine. For example, the following should be used to match the .git folder and its contents:

```
--cx-flow.zip-exclude=\.git/.*
```

Experimentation also shows that enclosing the regular expression in quotes leads to these being considered part of the regular expression(s).

See the following commits and their associated runs:

Commit [e9c8243](https://github.com/james-bostock-cx/cxflow-github-action-test/commit/e9c8243ba5d35ac39ab5046f9aac3e6c89e3d161) (run [4001509384](https://github.com/james-bostock-cx/cxflow-github-action-test/actions/runs/4001509384))
Commit [ddf5258](https://github.com/james-bostock-cx/cxflow-github-action-test/commit/ddf5258480959bb4472884f507a77c89791ed2d0) (run [4001545197](https://github.com/james-bostock-cx/cxflow-github-action-test/actions/runs/4001545197))
Commit [8ada1cb](https://github.com/james-bostock-cx/cxflow-github-action-test/commit/8ada1cb465502ec596093f571c75c756f531812d) (run [4001666677](https://github.com/james-bostock-cx/cxflow-github-action-test/actions/runs/4001666677))
Commit [96df8e9](https://github.com/james-bostock-cx/cxflow-github-action-test/commit/96df8e9a131a288a1691dc449d6399f038092684) (run [4002464979](https://github.com/james-bostock-cx/cxflow-github-action-test/actions/runs/4002464979))
Commit [aa61fe5](https://github.com/james-bostock-cx/cxflow-github-action-test/commit/aa61fe55c23f030b1458e0b5da4491d7267fa0e4) (run [4002501422](https://github.com/james-bostock-cx/cxflow-github-action-test/actions/runs/4002501422))
Commit [edc937b](https://github.com/james-bostock-cx/cxflow-github-action-test/commit/edc937b056dcfd8acdeea7c0406ca2261ec1de6d) (run [4002541564](https://github.com/james-bostock-cx/cxflow-github-action-test/actions/runs/4002541564))
