### PR TITLE
security: pin docker images to sha256 digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Use CxFlow Base image
-FROM checkmarx/cx-flow
+FROM checkmarx/cx-flow@sha256:feedcf239a910df30ac2dcbe580bfa05eb916d70e021bb62ea8d4ff72d8add77
 #Copy script to import certs into Java cacerts keystore
 COPY scripts/keytool-import-certs.sh /app/keytool-import-certs.sh
 #Make it executable


### PR DESCRIPTION
Replaces 1 image references across 1 files with @sha256:<digest>
pinned forms. Defends against tag mutation / supply-chain attacks.

Pinned images:
  - checkmarx/cx-flow -> checkmarx/cx-flow@sha256:feedcf239a910df30ac2dcbe580bfa05eb916d70e021bb62ea8d4ff72d8add77

Generated by docker-image-pinner from plan-20260616-160311.csv.